### PR TITLE
sema + donate_one + donate_multiple + multiple2

### DIFF
--- a/include/threads/synch.h
+++ b/include/threads/synch.h
@@ -22,7 +22,8 @@ struct lock {
 	struct semaphore semaphore; /* Binary semaphore controlling access. */
 
 	struct list_elem lock_elem; /* list element for locks*/
-	
+	int lock_priority;
+
 };
 
 void lock_init (struct lock *);

--- a/include/threads/synch.h
+++ b/include/threads/synch.h
@@ -20,6 +20,9 @@ void sema_self_test (void);
 struct lock {
 	struct thread *holder;      /* Thread holding lock (for debugging). */
 	struct semaphore semaphore; /* Binary semaphore controlling access. */
+
+	struct list_elem lock_elem; /* list element for locks*/
+	
 };
 
 void lock_init (struct lock *);

--- a/include/threads/thread.h
+++ b/include/threads/thread.h
@@ -97,7 +97,9 @@ struct thread {
 	int has_lock;
 	/* Shared between thread.c and synch.c. */
 	struct list_elem elem;              /* List element. */
-	struct list locks;					/* 해당 쓰레드가 갖고 있는 락들의 목록*/
+	struct list_elem donor_elem;
+	struct list donors;					/* 해당 쓰레드에 기부한 목록*/
+	struct lock *wait_on_lock;			/* 이 락이 없어서 못 가고 있을 때*/
 
 #ifdef USERPROG
 	/* Owned by userprog/process.c. */

--- a/include/threads/thread.h
+++ b/include/threads/thread.h
@@ -94,9 +94,10 @@ struct thread {
 	int priority;                       /* Priority. */
 	int original_priority;				/* 원래의 우선도(priority)*/
 	int64_t sleep_ticks; 				/* 자고 있는 시간*/
-	bool has_lock;
+	int has_lock;
 	/* Shared between thread.c and synch.c. */
 	struct list_elem elem;              /* List element. */
+	struct list locks;					/* 해당 쓰레드가 갖고 있는 락들의 목록*/
 
 #ifdef USERPROG
 	/* Owned by userprog/process.c. */

--- a/threads/synch.c
+++ b/threads/synch.c
@@ -78,7 +78,7 @@ sema_down (struct semaphore *sema) {
 		list_insert_ordered(&sema->waiters, &thread_current()->elem, sema_priority, NULL);
 		thread_block ();
 	}
-	thread_current()->has_lock = true;
+	thread_current()->has_lock += 1;
 	sema->value--;
 	intr_set_level (old_level);
 }
@@ -128,6 +128,7 @@ sema_up (struct semaphore *sema) {
 	{	
 		thread_current()->priority = thread_current()->original_priority;
 	}
+	thread_current()->has_lock -= 1;
 	sema->value++;
 	if (sema_top_priority!=NULL && sema_top_priority->priority > thread_current()->priority)
 		thread_yield();

--- a/threads/thread.c
+++ b/threads/thread.c
@@ -224,11 +224,7 @@ thread_create (const char *name, int priority,
 // //		thread_current()->priority = t->priority; 
 // 	}
 	if (thread_get_priority() < priority){
-		if(aux != NULL && thread_current()->has_lock > 0)
-		{
-			thread_current()->priority = priority;
-			// list_sort(&ready_list,priority_scheduling,NULL);
-		}
+
 		thread_yield();		
 	}
 	// thread_set_priority(priority);
@@ -267,6 +263,8 @@ thread_unblock (struct thread *t) {
 
 	old_level = intr_disable ();
 	ASSERT (t->status == THREAD_BLOCKED);
+
+	/* 쓰레드가 언블락되면 ready_list에 우선순위에 따라서 넣는 부분 */
 	list_insert_ordered(&ready_list, &t->elem, priority_scheduling, NULL);
 	//list_push_back (&ready_list, &t->elem);
 	t->status = THREAD_READY;
@@ -333,6 +331,7 @@ thread_yield (void) {
 	if (curr != idle_thread){
 		// list_push_back (&ready_list, &curr->elem);
 		//우선순위 스케쥴링
+		/* yield를 할 때 현재 쓰레드를 ready_list에 우선순위에 따른 위치에 맞게 넣는 부분 */
 		list_insert_ordered(&ready_list, &curr->elem, priority_scheduling, NULL);
 	}
 	do_schedule (THREAD_READY);
@@ -455,6 +454,8 @@ init_thread (struct thread *t, const char *name, int priority) {
 	t->original_priority = priority;
 	t->magic = THREAD_MAGIC;
 	t->has_lock = 0;
+	t->wait_on_lock = NULL;
+	list_init(&t->donors);
 }
 
 /* Chooses and returns the next thread to be scheduled.  Should

--- a/threads/thread.c
+++ b/threads/thread.c
@@ -224,7 +224,7 @@ thread_create (const char *name, int priority,
 // //		thread_current()->priority = t->priority; 
 // 	}
 	if (thread_get_priority() < priority){
-		if(aux != NULL && thread_current()->has_lock)
+		if(aux != NULL && thread_current()->has_lock > 0)
 		{
 			thread_current()->priority = priority;
 			// list_sort(&ready_list,priority_scheduling,NULL);
@@ -454,7 +454,7 @@ init_thread (struct thread *t, const char *name, int priority) {
 	t->priority = priority;
 	t->original_priority = priority;
 	t->magic = THREAD_MAGIC;
-	t->has_lock = false;
+	t->has_lock = 0;
 }
 
 /* Chooses and returns the next thread to be scheduled.  Should


### PR DESCRIPTION
pass tests/threads/alarm-single
pass tests/threads/alarm-multiple
pass tests/threads/alarm-simultaneous
pass tests/threads/alarm-priority
pass tests/threads/alarm-zero
pass tests/threads/alarm-negative
pass tests/threads/priority-change
pass tests/threads/priority-donate-one
pass tests/threads/priority-donate-multiple
pass tests/threads/priority-donate-multiple2
FAIL tests/threads/priority-donate-nest
pass tests/threads/priority-donate-sema
FAIL tests/threads/priority-donate-lower
FAIL tests/threads/priority-fifo
pass tests/threads/priority-preempt
FAIL tests/threads/priority-sema
FAIL tests/threads/priority-condvar
FAIL tests/threads/priority-donate-chain
FAIL tests/threads/mlfqs/mlfqs-load-1
FAIL tests/threads/mlfqs/mlfqs-load-60
FAIL tests/threads/mlfqs/mlfqs-load-avg
FAIL tests/threads/mlfqs/mlfqs-recent-1
pass tests/threads/mlfqs/mlfqs-fair-2
pass tests/threads/mlfqs/mlfqs-fair-20
FAIL tests/threads/mlfqs/mlfqs-nice-2
FAIL tests/threads/mlfqs/mlfqs-nice-10
FAIL tests/threads/mlfqs/mlfqs-block
13 of 27 tests failed.