### PR TITLE
fixed infinite wait

### DIFF
--- a/userprog/process.c
+++ b/userprog/process.c
@@ -110,7 +110,7 @@ process_fork (const char *name, struct intr_frame *if_) {
 	/* Clone current thread to new thread.*/
 	// thread_current()->tf = if_;
 	struct thread *cur = thread_current();
-	memcpy(&cur->parent_tf, &if_, sizeof(struct intr_frame));
+	memcpy(&cur->parent_tf, if_, sizeof(struct intr_frame));
 
 	tid_t tid = thread_create(name, PRI_DEFAULT, __do_fork, cur);
 	if (tid = TID_ERROR){
@@ -344,13 +344,22 @@ process_exit (void) {
 	 * TODO: We recommend you to implement process resource cleanup here. */
 	struct thread *t = thread_current();
 
-	int fd = 2; 
-	for(struct list_elem *e = list_begin(&t->fd_table); e != NULL ; e = list_next(&t->fd_table)){
-		fd ++;
-		close (fd);	
+	struct list *exit_list = &t->fd_table;
+	struct list_elem *e = list_begin(&exit_list);
+	while (!list_empty(exit_list)){
+		struct file_descriptor *exit_fd = list_entry(e, struct file_descriptor, fd_elem);
+		file_close(exit_fd->file);
+		e = list_remove(&exit_fd->fd_elem);
+		free(exit_fd);
 	}
+
+	// int fd = 2; 
+	// for(struct list_elem *e = list_begin(&t->fd_table); e != NULL ; e = list_next(&t->fd_table)){
+	// 	fd ++;
+	// 	close (fd);	
+	// }
 	file_close(t->running);
-	// t->exit_status = THREAD_DYING;
+	t->exit_status = THREAD_DYING;
 	process_cleanup();
 	sema_up(&t->wait_sema);
 	sema_down(&t->exit_sema);

--- a/userprog/syscall.c
+++ b/userprog/syscall.c
@@ -14,6 +14,7 @@
 #include "lib/string.h"
 #include "filesys/filesys.h"
 #include "filesys/file.h"
+#include "userprog/process.h"
 
 void syscall_entry (void);
 void syscall_handler (struct intr_frame *);
@@ -181,7 +182,7 @@ syscall_handler (struct intr_frame *f) {
 		break;
 
 	case SYS_TELL:
-		tell(f->R.rdi);
+		f->R.rax = tell(f->R.rdi);
 		break;
 
 	case SYS_CLOSE:
@@ -213,7 +214,7 @@ void exit(int status)
 
 tid_t fork (const char *thread_name){
 	
-	process_fork(thread_name, thread_current()->tf);
+	return process_fork(thread_name, &thread_current()->tf);
 }
 
 //현재 프로세스를 file로 바꿈
@@ -237,7 +238,7 @@ int exec (const char *file){
 int wait (tid_t t)
 {		
 
-	process_wait(t); 
+	return process_wait(t); 
 }
 
 //file이라는 파일을 만들고, 성공시 true 반환
@@ -355,7 +356,7 @@ unsigned tell (int fd)
 	struct file_descriptor *file_desc = find_file_descriptor(fd);
 	if(file_desc == NULL)
 		return -1;
-	file_tell(file_desc->file);
+	return file_tell(&file_desc->file);
 }
 
 void close (int fd) {


### PR DESCRIPTION
pass tests/userprog/args-none
pass tests/userprog/args-single
pass tests/userprog/args-multiple
pass tests/userprog/args-many
pass tests/userprog/args-dbl-space
pass tests/userprog/halt
pass tests/userprog/exit
pass tests/userprog/create-normal
pass tests/userprog/create-empty
pass tests/userprog/create-null
pass tests/userprog/create-bad-ptr
pass tests/userprog/create-long
pass tests/userprog/create-exists
pass tests/userprog/create-bound
FAIL tests/userprog/open-normal
pass tests/userprog/open-missing
FAIL tests/userprog/open-boundary
pass tests/userprog/open-empty
pass tests/userprog/open-null
pass tests/userprog/open-bad-ptr
FAIL tests/userprog/open-twice
pass tests/userprog/close-normal
pass tests/userprog/close-twice
pass tests/userprog/close-bad-fd
pass tests/userprog/read-normal
FAIL tests/userprog/read-bad-ptr
FAIL tests/userprog/read-boundary
FAIL tests/userprog/read-zero
pass tests/userprog/read-stdout
pass tests/userprog/read-bad-fd
FAIL tests/userprog/write-normal
FAIL tests/userprog/write-bad-ptr
FAIL tests/userprog/write-boundary
FAIL tests/userprog/write-zero
pass tests/userprog/write-stdin
pass tests/userprog/write-bad-fd
FAIL tests/userprog/fork-once
FAIL tests/userprog/fork-multiple
FAIL tests/userprog/fork-recursive
FAIL tests/userprog/fork-read
FAIL tests/userprog/fork-close
FAIL tests/userprog/fork-boundary
pass tests/userprog/exec-once
FAIL tests/userprog/exec-arg
FAIL tests/userprog/exec-boundary
FAIL tests/userprog/exec-missing
pass tests/userprog/exec-bad-ptr
FAIL tests/userprog/exec-read
FAIL tests/userprog/wait-simple
FAIL tests/userprog/wait-twice
FAIL tests/userprog/wait-killed
FAIL tests/userprog/wait-bad-pid
FAIL tests/userprog/multi-recurse
FAIL tests/userprog/multi-child-fd
FAIL tests/userprog/rox-simple
FAIL tests/userprog/rox-child
FAIL tests/userprog/rox-multichild
FAIL tests/userprog/bad-read
FAIL tests/userprog/bad-write
FAIL tests/userprog/bad-read2
FAIL tests/userprog/bad-write2
FAIL tests/userprog/bad-jump
FAIL tests/userprog/bad-jump2
pass tests/filesys/base/lg-create
pass tests/filesys/base/lg-full
pass tests/filesys/base/lg-random
pass tests/filesys/base/lg-seq-block
pass tests/filesys/base/lg-seq-random
pass tests/filesys/base/sm-create
pass tests/filesys/base/sm-full
pass tests/filesys/base/sm-random
pass tests/filesys/base/sm-seq-block
pass tests/filesys/base/sm-seq-random
FAIL tests/filesys/base/syn-read
pass tests/filesys/base/syn-remove
FAIL tests/filesys/base/syn-write
FAIL tests/userprog/no-vm/multi-oom
pass tests/threads/alarm-single
pass tests/threads/alarm-multiple
pass tests/threads/alarm-simultaneous
pass tests/threads/alarm-priority
pass tests/threads/alarm-zero
pass tests/threads/alarm-negative
pass tests/threads/priority-change
pass tests/threads/priority-donate-one
pass tests/threads/priority-donate-multiple
pass tests/threads/priority-donate-multiple2
pass tests/threads/priority-donate-nest
pass tests/threads/priority-donate-sema
pass tests/threads/priority-donate-lower
pass tests/threads/priority-fifo
pass tests/threads/priority-preempt
pass tests/threads/priority-sema
pass tests/threads/priority-condvar
pass tests/threads/priority-donate-chain
38 of 95 tests failed.