### PR TITLE
WIP

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -22,7 +22,8 @@
         "inode.h": "c",
         "malloc.h": "c",
         "tests.h": "c",
-        "palloc.h": "c"
+        "palloc.h": "c",
+        "stdio.h": "c"
     },
     "C_Cpp.errorSquiggles": "disabled"
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -20,7 +20,9 @@
         "syscall-nr.h": "c",
         "filesys.h": "c",
         "inode.h": "c",
-        "malloc.h": "c"
+        "malloc.h": "c",
+        "tests.h": "c",
+        "palloc.h": "c"
     },
     "C_Cpp.errorSquiggles": "disabled"
 }

--- a/include/threads/thread.h
+++ b/include/threads/thread.h
@@ -184,7 +184,6 @@ void update_priority();
 void calculate_all_priority();
 void try_thread_yield();
 
-
 #endif /* threads/thread.h */
 
 #ifdef USERPROG

--- a/include/userprog/process.h
+++ b/include/userprog/process.h
@@ -6,7 +6,7 @@
 tid_t process_create_initd (const char *file_name);
 tid_t process_fork (const char *name, struct intr_frame *if_ UNUSED);
 int process_exec (void *f_name);
-int process_wait (tid_t);
+int process_wait (tid_t UNUSED);
 void process_exit (void);
 void process_activate (struct thread *next);
 

--- a/include/userprog/process.h
+++ b/include/userprog/process.h
@@ -4,7 +4,7 @@
 #include "threads/thread.h"
 
 tid_t process_create_initd (const char *file_name);
-tid_t process_fork (const char *name, struct intr_frame *if_);
+tid_t process_fork (const char *name, struct intr_frame *if_ UNUSED);
 int process_exec (void *f_name);
 int process_wait (tid_t);
 void process_exit (void);

--- a/include/userprog/syscall.h
+++ b/include/userprog/syscall.h
@@ -1,8 +1,9 @@
 #ifndef USERPROG_SYSCALL_H
 #define USERPROG_SYSCALL_H
+#include "threads/synch.h"
 
 void syscall_init (void);
-
 void close(int fd);
+struct lock filesys_lock;
 // 구현
 #endif /* userprog/syscall.h */

--- a/threads/mmu.c
+++ b/threads/mmu.c
@@ -236,7 +236,15 @@ pml4_get_page (uint64_t *pml4, const void *uaddr) {
  * If WRITABLE is true, the new page is read/write;
  * otherwise it is read-only.
  * Returns true if successful, false if memory allocation
- * failed. */
+ * failed. 
+ * 사용자 가상 페이지 UPAGE에서 커널 가상 주소 KPAGE로 식별된 물리적 프레임에 
+ * 페이지 맵 레벨 4 PML4의 매핑을 추가합니다.
+ * UPAGE가 이미 매핑되어 있으면 안 됩니다. 
+ * KPAGE는 palloc_get_page()가 있는 사용자 풀에서 가져온 페이지여야 합니다.
+ * WRETRABLE이 참이면 새 페이지를 읽고 쓸 수 있습니다;
+ * 그렇지 않으면 읽기 전용입니다.
+ * 성공하면 true, 메모리 할당에 실패하면 false를 반환합니다.
+ */
 bool
 pml4_set_page (uint64_t *pml4, void *upage, void *kpage, bool rw) {
 	ASSERT (pg_ofs (upage) == 0);

--- a/threads/palloc.c
+++ b/threads/palloc.c
@@ -258,7 +258,14 @@ palloc_init (void) {
    otherwise from the kernel pool.  If PAL_ZERO is set in FLAGS,
    then the pages are filled with zeros.  If too few pages are
    available, returns a null pointer, unless PAL_ASSERT is set in
-   FLAGS, in which case the kernel panics. */
+   FLAGS, in which case the kernel panics. 
+ * PAGE_CNT 연속 사용 가능 페이지 그룹을 가져와 반환합니다.
+ * PAL_USER가 설정되어 있으면 페이지는 사용자 풀, 
+ * 그렇지 않으면 커널 풀에서 가져옵니다. 
+ * FLAGs에서 PAL_ZERO가 설정되어 있으면 페이지는 0으로 채워집니다. 
+ * 페이지가 너무 적으면 FLAGs에서 PAL_ASSERT가 설정되어 있지 않으면 
+ * Null 포인터를 반환합니다. 이 경우 커널은 패닉 상태가 됩니다.
+ */
 void *
 palloc_get_multiple (enum palloc_flags flags, size_t page_cnt) {
 	struct pool *pool = flags & PAL_USER ? &user_pool : &kernel_pool;

--- a/threads/thread.c
+++ b/threads/thread.c
@@ -220,8 +220,7 @@ thread_print_stats (void) {
    PRIORITY, but no actual priority scheduling is implemented.
    Priority scheduling is the goal of Problem 1-3. */
 tid_t
- thread_create (const char *name, int priority,
-		thread_func *function, void *aux) {
+ thread_create (const char *name, int priority, thread_func *function, void *aux) {
 	struct thread *t;
 	tid_t tid;
 
@@ -890,4 +889,5 @@ int allocate_fd(struct file *file, struct list *fd_table)
 	list_push_back(fd_table,&file_descriptor->fd_elem);
 	return file_descriptor->fd;
 }
+
 #endif

--- a/userprog/process.c
+++ b/userprog/process.c
@@ -106,11 +106,11 @@ initd (void *f_name) {
  * 스레드를 만들 수 없는 경우 TID_ERROR입니다.
  */
 tid_t
-process_fork (const char *name, struct intr_frame *if_) {
+process_fork (const char *name, struct intr_frame *if_ UNUSED) {
 	/* Clone current thread to new thread.*/
 	// thread_current()->tf = if_;
 	struct thread *cur = thread_current();
-	memcpy(&cur->parent_tf, &if_, sizeof(struct intr_frame));
+	memcpy(&cur->parent_tf, if_, sizeof(struct intr_frame));
 
 	tid_t tid = thread_create(name, PRI_DEFAULT, __do_fork, cur);
 	if (tid = TID_ERROR){
@@ -841,9 +841,11 @@ void argument_stack (char **argv, int argc, struct intr_frame *if_){
 struct thread *get_thread_from_tid(tid_t thread_id){
 
 	struct thread * t = thread_current();
-	struct list_elem* e = list_front(&t->child_list);
+	struct list* child_list = &t->child_list;
+	struct list_elem* e;
 
-	for (e = list_begin (&t->child_list); e != list_end (&t->child_list); e = list_next (e)){
+	for (e = list_begin (child_list); e != list_end (child_list); e = list_next (e))
+	{
 		t = list_entry(e, struct thread, child_list_elem);
 		if (t->tid == thread_id){
 			return t;

--- a/userprog/syscall.c
+++ b/userprog/syscall.c
@@ -102,7 +102,7 @@ syscall_init (void) {
 	write_msr(MSR_SYSCALL_MASK,
 			FLAG_IF | FLAG_TF | FLAG_DF | FLAG_IOPL | FLAG_AC | FLAG_NT);
 
-	
+	lock_init(&filesys_lock);
 }
 
 /* The main system call interface */
@@ -239,7 +239,6 @@ int exec (const char *file){
 //자식 프로세스 tid가 끝날때까지 기다림 & 자식프로세스의 status를 반환함
 int wait (tid_t t)
 {		
-
 	return process_wait(t); 
 }
 

--- a/userprog/syscall.c
+++ b/userprog/syscall.c
@@ -284,7 +284,22 @@ int open (const char *file)
 	return fd;
 }
 
-//열린 파일 (fd로 식별)의 크기를 반환 (바이트 단위)
+void close (int fd) {
+	struct file_descriptor *file_desc = find_file_descriptor(fd);
+	if(file_desc == NULL)
+		return;
+	file_close(file_desc->file);
+	list_remove(&file_desc->fd_elem);
+	free(file_desc);
+
+}
+bool remove (const char *file)
+{
+	struct dir *dir = dir_open_root ();
+	bool success = dir != NULL && dir_remove (dir, file);
+	dir_close (dir);
+	return success;
+}
 int filesize (int fd)
 {
 	struct file_descriptor *file_desc = find_file_descriptor(fd);

--- a/userprog/syscall.c
+++ b/userprog/syscall.c
@@ -215,7 +215,7 @@ void exit(int status)
 
 tid_t fork (const char *thread_name){
 	
-	process_fork(thread_name, &thread_current()->tf);
+	return process_fork(thread_name, &thread_current()->tf);
 }
 
 //현재 프로세스를 file로 바꿈

--- a/userprog/syscall.c
+++ b/userprog/syscall.c
@@ -215,7 +215,7 @@ void exit(int status)
 
 tid_t fork (const char *thread_name){
 	
-	process_fork(thread_name, thread_current()->tf);
+	process_fork(thread_name, &thread_current()->tf);
 }
 
 //현재 프로세스를 file로 바꿈
@@ -283,7 +283,6 @@ int open (const char *file)
 
 	return fd;
 }
-
 void close (int fd) {
 	struct file_descriptor *file_desc = find_file_descriptor(fd);
 	if(file_desc == NULL)
@@ -292,13 +291,6 @@ void close (int fd) {
 	list_remove(&file_desc->fd_elem);
 	free(file_desc);
 
-}
-bool remove (const char *file)
-{
-	struct dir *dir = dir_open_root ();
-	bool success = dir != NULL && dir_remove (dir, file);
-	dir_close (dir);
-	return success;
 }
 int filesize (int fd)
 {


### PR DESCRIPTION
pass tests/userprog/args-none
pass tests/userprog/args-single
pass tests/userprog/args-multiple
pass tests/userprog/args-many
pass tests/userprog/args-dbl-space
pass tests/userprog/halt
pass tests/userprog/exit
pass tests/userprog/create-normal
pass tests/userprog/create-empty
pass tests/userprog/create-null
pass tests/userprog/create-bad-ptr
pass tests/userprog/create-long
pass tests/userprog/create-exists
pass tests/userprog/create-bound
pass tests/userprog/open-normal
pass tests/userprog/open-missing
pass tests/userprog/open-boundary
pass tests/userprog/open-empty
pass tests/userprog/open-null
pass tests/userprog/open-bad-ptr
pass tests/userprog/open-twice
pass tests/userprog/close-normal
pass tests/userprog/close-twice
pass tests/userprog/close-bad-fd
pass tests/userprog/read-normal
pass tests/userprog/read-bad-ptr
pass tests/userprog/read-boundary
pass tests/userprog/read-zero
pass tests/userprog/read-stdout
pass tests/userprog/read-bad-fd
pass tests/userprog/write-normal
pass tests/userprog/write-bad-ptr
pass tests/userprog/write-boundary
pass tests/userprog/write-zero
pass tests/userprog/write-stdin
pass tests/userprog/write-bad-fd
FAIL tests/userprog/fork-once
FAIL tests/userprog/fork-multiple
FAIL tests/userprog/fork-recursive
FAIL tests/userprog/fork-read
FAIL tests/userprog/fork-close
FAIL tests/userprog/fork-boundary
pass tests/userprog/exec-once
FAIL tests/userprog/exec-arg
FAIL tests/userprog/exec-boundary
FAIL tests/userprog/exec-missing
pass tests/userprog/exec-bad-ptr
FAIL tests/userprog/exec-read
FAIL tests/userprog/wait-simple
FAIL tests/userprog/wait-twice
FAIL tests/userprog/wait-killed
pass tests/userprog/wait-bad-pid
FAIL tests/userprog/multi-recurse
FAIL tests/userprog/multi-child-fd
FAIL tests/userprog/rox-simple
FAIL tests/userprog/rox-child
FAIL tests/userprog/rox-multichild
FAIL tests/userprog/bad-read
FAIL tests/userprog/bad-write
FAIL tests/userprog/bad-read2
FAIL tests/userprog/bad-write2
FAIL tests/userprog/bad-jump
FAIL tests/userprog/bad-jump2
pass tests/filesys/base/lg-create
pass tests/filesys/base/lg-full
pass tests/filesys/base/lg-random
pass tests/filesys/base/lg-seq-block
pass tests/filesys/base/lg-seq-random
pass tests/filesys/base/sm-create
pass tests/filesys/base/sm-full
pass tests/filesys/base/sm-random
pass tests/filesys/base/sm-seq-block
pass tests/filesys/base/sm-seq-random
FAIL tests/filesys/base/syn-read
pass tests/filesys/base/syn-remove
FAIL tests/filesys/base/syn-write
FAIL tests/userprog/no-vm/multi-oom
pass tests/threads/alarm-single
pass tests/threads/alarm-multiple
pass tests/threads/alarm-simultaneous
pass tests/threads/alarm-priority
pass tests/threads/alarm-zero
pass tests/threads/alarm-negative
pass tests/threads/priority-change
pass tests/threads/priority-donate-one
pass tests/threads/priority-donate-multiple
pass tests/threads/priority-donate-multiple2
pass tests/threads/priority-donate-nest
pass tests/threads/priority-donate-sema
pass tests/threads/priority-donate-lower
pass tests/threads/priority-fifo
pass tests/threads/priority-preempt
pass tests/threads/priority-sema
pass tests/threads/priority-condvar
pass tests/threads/priority-donate-chain
27 of 95 tests failed.