### PR TITLE
Jaenam615

### DIFF
--- a/userprog/syscall.c
+++ b/userprog/syscall.c
@@ -227,16 +227,14 @@ int exec (const char *file){
 		exit(-1);
 
 	char* file_in_kernel;
-	file_in_kernel = palloc_get_page(0);
+	file_in_kernel = palloc_get_page(PAL_ZERO);
 
 	if (file_in_kernel == NULL)
 		exit(-1);
-	strlcpy(file_in_kernel, file, PGSIZE);
+	strlcpy(file_in_kernel, file, strlen(file) +1);
 	
 	if (process_exec(file_in_kernel) == -1)
-		return -1;
-
-		
+		return -1;	
 }
 
 //자식 프로세스 tid가 끝날때까지 기다림 & 자식프로세스의 status를 반환함
@@ -337,67 +335,152 @@ int read (int fd, void *buffer, unsigned size)
 {
 	if(pml4_get_page(thread_current()->pml4, buffer) == NULL || buffer == NULL || !is_user_vaddr(buffer) || fd < 0)
 		exit(-1);
-	int byte = 0;
-	char* _buffer = buffer;
-	if(fd == 0)
+	// int byte = 0;
+	// char* _buffer = buffer;
+	// if(fd == 0)
+	// {
+	// 	while(byte < size)
+	// 	{
+	// 		_buffer[byte++] = input_getc();
+	// 	}
+	// }
+	// else if(fd == 1)
+	// {
+	// 	return -1;
+	// }
+	// else
+	// {
+	// 	struct file_descriptor *file_desc = find_file_descriptor(fd);
+	// 	if(file_desc == NULL)
+	// 		return -1;
+	// 	byte = file_read(file_desc->file,buffer,size);
+	// }
+	// return byte;
+
+	struct thread *curr = thread_current();
+	struct list_elem *start;
+	off_t buff_size;
+
+	if (fd == 0)
 	{
-		while(byte < size)
-		{
-			_buffer[byte++] = input_getc();
-		}
+		return input_getc();
 	}
-	else if(fd == 1)
+	else if (fd < 0 || fd == NULL || fd == 1)
 	{
-		return -1;
+		exit(-1);
 	}
+	// bad-fd는 page-fault를 일으키기 때문에 page-fault를 처리하는 함수에서 확인
 	else
 	{
-		struct file_descriptor *file_desc = find_file_descriptor(fd);
-		if(file_desc == NULL)
-			return -1;
-		byte = file_read(file_desc->file,buffer,size);
+		for (start = list_begin(&curr->fd_table); start != list_end(&curr->fd_table); start = list_next(start))
+		{
+			struct file_descriptor *read_fd = list_entry(start, struct file_descriptor, fd_elem);
+			if (read_fd->fd == fd)
+			{
+				lock_acquire(&filesys_lock);
+				buff_size = file_read(read_fd->file, buffer, size);
+				lock_release(&filesys_lock);
+			}
+		}
 	}
-	return byte;
+	return buff_size;
+
 }
 
 int write (int fd, const void *buffer, unsigned size)
 {
 	if(pml4_get_page(thread_current()->pml4, buffer) == NULL || buffer == NULL || !is_user_vaddr(buffer) || fd < 0)
 		exit(-1);
-	char* _buffer = buffer;
-	if(fd == 0)
+	// char* _buffer = buffer;
+	// if(fd == 0)
+	// {
+	// 	return -1;
+	// }
+	// else if(fd == 1)
+	// {
+	// 	putbuf(_buffer,size);
+	// 	return size;
+	// }
+	// else
+	// {
+	// 	struct file_descriptor *file_desc = find_file_descriptor(fd);
+	// 	if(file_desc == NULL)
+	// 		return -1;
+	// 	file_write(file_desc->file,_buffer,size);
+	// 	return size;
+	// }
+
+	struct thread *curr = thread_current();
+	struct list_elem *start;
+	if (fd == 1)
 	{
-		return -1;
-	}
-	else if(fd == 1)
-	{
-		putbuf(_buffer,size);
+		putbuf(buffer, size);
 		return size;
+		// fd == 1이라는 의미는 표준 출력을 의미함. 따라서 화면에 입력된 데이터를 출력하는 함수 pufbuf를 호출.
+		// putbuf 함수는 buffer에 입력된 데이터를 size만큼 화면에 출력하는 함수.
+		// 이후 버퍼의 크기 -> size를 반환한다.
 	}
-	else
+	else if (fd < 0 || fd == NULL)
 	{
-		struct file_descriptor *file_desc = find_file_descriptor(fd);
-		if(file_desc == NULL)
-			return -1;
-		file_write(file_desc->file,_buffer,size);
-		return size;
+		exit(-1);
+	}
+	for (start = list_begin(&curr->fd_table); start != list_end(&curr->fd_table); start = list_next(start))
+	{
+		struct file_descriptor *write_fd = list_entry(start, struct file_descriptor, fd_elem);
+		if (write_fd->fd == fd)
+		{
+			lock_acquire(&filesys_lock);
+			off_t write_size = file_write(write_fd->file, buffer, size);
+			// fd == 0 과 fd == 1은 표준 입출력을 의미하는 파일 식별자이기 때문에 해당되는 파일이 존재하지 않는다.
+			// 따라서 정상적인 write가 이루어지지 않는다. fd == 1이면 write 함수의 반환값은 0임.
+			lock_release(&filesys_lock);
+			return write_size;
+		}
 	}
 }
 
 void seek (int fd, unsigned position)
 {
-	struct file_descriptor *file_desc = find_file_descriptor(fd);
-	if(file_desc == NULL)
-		return -1;
-	file_seek(file_desc->file, position);
+	// struct file_descriptor *file_desc = find_file_descriptor(fd);
+	// if(file_desc == NULL)
+	// 	return -1;
+	// file_seek(file_desc->file, position);
+
+
+	struct thread *curr = thread_current();
+	struct list_elem *start;
+
+	for (start = list_begin(&curr->fd_table); start != list_end(&curr->fd_table); start = list_next(start))
+	{
+		struct file_descriptor *seek_fd = list_entry(start, struct file_descriptor, fd_elem);
+		if (seek_fd->fd == fd)
+		{
+			return file_seek(seek_fd->file, position);
+		}
+	}
+
+
 }
 
 unsigned tell (int fd)
 {
-	struct file_descriptor *file_desc = find_file_descriptor(fd);
-	if(file_desc == NULL)
-		return -1;
-	return file_tell(&file_desc->file);
+	// struct file_descriptor *file_desc = find_file_descriptor(fd);
+	// if(file_desc == NULL)
+	// 	return -1;
+	// return file_tell(&file_desc->file);
+
+	struct thread *curr = thread_current();
+	struct list_elem *start;
+
+	for (start = list_begin(&curr->fd_table); start != list_end(&curr->fd_table); start = list_next(start))
+	{
+		struct file_descriptor *tell_fd = list_entry(start, struct file_descriptor, fd_elem);
+		if (tell_fd->fd == fd)
+		{
+			return file_tell(tell_fd->file);
+		}
+	}
+
 }
 
 // pid_t fork (const char *thread_name)


### PR DESCRIPTION
pass tests/userprog/args-none
pass tests/userprog/args-single
pass tests/userprog/args-multiple
pass tests/userprog/args-many
pass tests/userprog/args-dbl-space
pass tests/userprog/halt
pass tests/userprog/exit
pass tests/userprog/create-normal
pass tests/userprog/create-empty
pass tests/userprog/create-null
pass tests/userprog/create-bad-ptr
pass tests/userprog/create-long
pass tests/userprog/create-exists
pass tests/userprog/create-bound
pass tests/userprog/open-normal
pass tests/userprog/open-missing
pass tests/userprog/open-boundary
pass tests/userprog/open-empty
pass tests/userprog/open-null
pass tests/userprog/open-bad-ptr
pass tests/userprog/open-twice
pass tests/userprog/close-normal
pass tests/userprog/close-twice
pass tests/userprog/close-bad-fd
pass tests/userprog/read-normal
pass tests/userprog/read-bad-ptr
pass tests/userprog/read-boundary
pass tests/userprog/read-zero
pass tests/userprog/read-stdout
pass tests/userprog/read-bad-fd
pass tests/userprog/write-normal
pass tests/userprog/write-bad-ptr
pass tests/userprog/write-boundary
pass tests/userprog/write-zero
pass tests/userprog/write-stdin
pass tests/userprog/write-bad-fd
FAIL tests/userprog/fork-once
FAIL tests/userprog/fork-multiple
FAIL tests/userprog/fork-recursive
FAIL tests/userprog/fork-read
FAIL tests/userprog/fork-close
FAIL tests/userprog/fork-boundary
pass tests/userprog/exec-once
FAIL tests/userprog/exec-arg
FAIL tests/userprog/exec-boundary
FAIL tests/userprog/exec-missing
pass tests/userprog/exec-bad-ptr
FAIL tests/userprog/exec-read
FAIL tests/userprog/wait-simple
FAIL tests/userprog/wait-twice
FAIL tests/userprog/wait-killed
pass tests/userprog/wait-bad-pid
FAIL tests/userprog/multi-recurse
FAIL tests/userprog/multi-child-fd
pass tests/userprog/rox-simple
FAIL tests/userprog/rox-child
FAIL tests/userprog/rox-multichild
FAIL tests/userprog/bad-read
FAIL tests/userprog/bad-write
FAIL tests/userprog/bad-read2
FAIL tests/userprog/bad-write2
FAIL tests/userprog/bad-jump
FAIL tests/userprog/bad-jump2
pass tests/filesys/base/lg-create
pass tests/filesys/base/lg-full
pass tests/filesys/base/lg-random
pass tests/filesys/base/lg-seq-block
pass tests/filesys/base/lg-seq-random
pass tests/filesys/base/sm-create
pass tests/filesys/base/sm-full
pass tests/filesys/base/sm-random
pass tests/filesys/base/sm-seq-block
pass tests/filesys/base/sm-seq-random
FAIL tests/filesys/base/syn-read
pass tests/filesys/base/syn-remove
FAIL tests/filesys/base/syn-write
FAIL tests/userprog/no-vm/multi-oom
pass tests/threads/alarm-single
pass tests/threads/alarm-multiple
pass tests/threads/alarm-simultaneous
pass tests/threads/alarm-priority
pass tests/threads/alarm-zero
pass tests/threads/alarm-negative
pass tests/threads/priority-change
pass tests/threads/priority-donate-one
pass tests/threads/priority-donate-multiple
pass tests/threads/priority-donate-multiple2
pass tests/threads/priority-donate-nest
pass tests/threads/priority-donate-sema
pass tests/threads/priority-donate-lower
pass tests/threads/priority-fifo
pass tests/threads/priority-preempt
pass tests/threads/priority-sema
pass tests/threads/priority-condvar
pass tests/threads/priority-donate-chain
26 of 95 tests failed.